### PR TITLE
chore: improve client side plugin service error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ A Nitric SDK service invocation sequence diagram is provided below.
 
 1. SDK Client - Application process makes SDK service call via GRPC client
 2. GRPC Server - Membrane process GRPC server receives call, and registered service handles call [`/pkg/membrane`]
-3. GRPC Document Service - delegates the call to the service adaptor [`/interfaces/nitric/v1/doucment_grpc.pb.go`] 
+3. GRPC Document Service - delegates the call to the service adaptor [`/interfaces/nitric/v1/document_grpc.pb.go`] 
 4. GRPC Document Adaptor - service adaptor delegates call to Cloud service plugin [`/pkg/adapters/grpc/document_grpc.go`] 
 5. Document Service Plugin (DynamoDB) - Cloud service plugin makes remote call to Cloud's API [`/pkg/plugins/document/dynamodb/dynamodb.go`]
 6. DynamoDB API - Cloud API makes remote call to Cloud service

--- a/README.md
+++ b/README.md
@@ -117,9 +117,13 @@ Install a Java Runtime Environment (JRE) version 11 or later for your OS. For ex
 sudo apt-get install openjdk-11-jdk
 ```
 
-### Run tests
+### Run unit tests
 ```bash
 make tests
+```
+### Run integration tests
+```bash
+make test-integration
 ```
 
 ### Build Static Membranes
@@ -219,19 +223,20 @@ make aws-static-xp
 
 The Membrane project source code structure is outlined below:
 
-Directory               | Package    | Description
----------               |----------- |------------
-`/adapters/grpc`        | `grpc`     | GRPC service to SDK adaptors 
-`/worker`               | `worker`   | Membrane workers representing function/service connections
-`/interfaces/nitric/v1` | `v1`       | protoc generated GRPC services code 
-`/membrane`             | `membrane` | membrane application
-`/mocks/...`            | `...`      | Cloud service SDK mocks 
-`/plugins/...`          | `...`      | Cloud service SDK plugins 
-`/providers/...`        | `main`     | Cloud provider main application and plugin injection 
-`/sdk`                  | `sdk`      | SDK service interfaces 
-`/tools`                | `tools`    | include for 3rd party build tools
-`/triggers`             | `triggers` | provides Nitric event triggers
-`/utils`                | `utils`    | provides utility functions
+Directory                   | Package    | Description
+---------                   |----------- |------------
+`/interfaces/nitric/v1`     | `v1`       | protoc generated GRPC services code 
+`/pkg/adapters/grpc`        | `grpc`     | GRPC service to SDK adaptors 
+`/pkg/membrane`             | `membrane` | membrane application
+`/pkg/plugins/...`          | `...`      | Cloud service SDK plugins 
+`/pkg/providers/...`        | `main`     | Cloud provider main application and plugin injection 
+`/pkg/sdk`                  | `sdk`      | SDK service interfaces 
+`/pkg/triggers`             | `triggers` | provides Nitric event triggers
+`/pkg/utils`                | `utils`    | provides utility functions
+`/pkg/worker`               | `worker`   | Membrane workers representing function/service connections
+`/tests/mocks/...`          | `...`      | Cloud service SDK mocks 
+`/tests/plugins/...`        | `...`      | Plugin services integration test suites
+`/tools`                    | `tools`    | include for 3rd party build tools
 
 ## Membrane Service Invocation
 
@@ -242,8 +247,8 @@ A Nitric SDK service invocation sequence diagram is provided below.
 </p>
 
 1. SDK Client - Application process makes SDK service call via GRPC client
-2. gRPC Server - Membrane process gRPC server receives call, and registered service handles call [`/membrane`]
-3. gRPC Service KV - server delegates the call to the service adaptor [`/interfaces/nitric/v1`] 
-4. KV Adaptor (gRPC) - service adaptor delegates call to Cloud service plugin [`/adapters/grpc`] 
-5. KV Plugin (DynamoDB) - Cloud service plugin makes remote call to Cloud's API [`/plugins/...`]
+2. GRPC Server - Membrane process GRPC server receives call, and registered service handles call [`/pkg/membrane`]
+3. GRPC Document Service - delegates the call to the service adaptor [`/interfaces/nitric/v1/doucment_grpc.pb.go`] 
+4. GRPC Document Adaptor - service adaptor delegates call to Cloud service plugin [`/pkg/adapters/grpc/document_grpc.go`] 
+5. Document Service Plugin (DynamoDB) - Cloud service plugin makes remote call to Cloud's API [`/pkg/plugins/document/dynamodb/dynamodb.go`]
 6. DynamoDB API - Cloud API makes remote call to Cloud service

--- a/pkg/adapters/grpc/queue_grpc.go
+++ b/pkg/adapters/grpc/queue_grpc.go
@@ -19,8 +19,6 @@ import (
 
 	pb "github.com/nitric-dev/membrane/interfaces/nitric/v1"
 	"github.com/nitric-dev/membrane/pkg/sdk"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -30,28 +28,16 @@ type QueueServiceServer struct {
 	plugin sdk.QueueService
 }
 
-func (s *QueueServiceServer) checkPluginRegistered() (bool, error) {
-	if s.plugin == nil {
-		return false, status.Errorf(codes.Unimplemented, "Queue plugin not registered")
+func (s *QueueServiceServer) Send(ctx context.Context, req *pb.QueueSendRequest) (*pb.QueueSendResponse, error) {
+	task := req.GetTask()
+
+	nitricTask := sdk.NitricTask{
+		ID:          task.GetId(),
+		PayloadType: task.GetPayloadType(),
+		Payload:     task.GetPayload().AsMap(),
 	}
 
-	return true, nil
-}
-
-func (s *QueueServiceServer) Send(ctx context.Context, req *pb.QueueSendRequest) (*pb.QueueSendResponse, error) {
-	if ok, err := s.checkPluginRegistered(); ok {
-		task := req.GetTask()
-
-		nitricTask := sdk.NitricTask{
-			ID:          task.GetId(),
-			PayloadType: task.GetPayloadType(),
-			Payload:     task.GetPayload().AsMap(),
-		}
-
-		if err := s.plugin.Send(req.GetQueue(), nitricTask); err != nil {
-			return nil, err
-		}
-	} else {
+	if err := s.plugin.Send(req.GetQueue(), nitricTask); err != nil {
 		return nil, err
 	}
 
@@ -60,95 +46,83 @@ func (s *QueueServiceServer) Send(ctx context.Context, req *pb.QueueSendRequest)
 }
 
 func (s *QueueServiceServer) SendBatch(ctx context.Context, req *pb.QueueSendBatchRequest) (*pb.QueueSendBatchResponse, error) {
-	if ok, err := s.checkPluginRegistered(); ok {
-		// Translate tasks
-		tasks := make([]sdk.NitricTask, len(req.GetTasks()))
-		for i, task := range req.GetTasks() {
-			tasks[i] = sdk.NitricTask{
-				ID:          task.GetId(),
-				PayloadType: task.GetPayloadType(),
-				Payload:     task.GetPayload().AsMap(),
-			}
+	// Translate tasks
+	tasks := make([]sdk.NitricTask, len(req.GetTasks()))
+	for i, task := range req.GetTasks() {
+		tasks[i] = sdk.NitricTask{
+			ID:          task.GetId(),
+			PayloadType: task.GetPayloadType(),
+			Payload:     task.GetPayload().AsMap(),
 		}
+	}
 
-		if resp, err := s.plugin.SendBatch(req.GetQueue(), tasks); err == nil {
-			failedTasks := make([]*pb.FailedTask, len(resp.FailedTasks))
-			for i, failedTask := range resp.FailedTasks {
-				st, _ := structpb.NewStruct(failedTask.Task.Payload)
-				failedTasks[i] = &pb.FailedTask{
-					Message: failedTask.Message,
-					Task: &pb.NitricTask{
-						Id:          failedTask.Task.ID,
-						PayloadType: failedTask.Task.PayloadType,
-						Payload:     st,
-					},
-				}
+	if resp, err := s.plugin.SendBatch(req.GetQueue(), tasks); err == nil {
+		failedTasks := make([]*pb.FailedTask, len(resp.FailedTasks))
+		for i, failedTask := range resp.FailedTasks {
+			st, _ := structpb.NewStruct(failedTask.Task.Payload)
+			failedTasks[i] = &pb.FailedTask{
+				Message: failedTask.Message,
+				Task: &pb.NitricTask{
+					Id:          failedTask.Task.ID,
+					PayloadType: failedTask.Task.PayloadType,
+					Payload:     st,
+				},
 			}
-			return &pb.QueueSendBatchResponse{
-				FailedTasks: failedTasks,
-			}, nil
-		} else {
-			return nil, err
 		}
+		return &pb.QueueSendBatchResponse{
+			FailedTasks: failedTasks,
+		}, nil
 	} else {
-		return nil, err
+		return nil, NewGrpcError("QueueService.SendBatch", err)
 	}
 }
 
 func (s *QueueServiceServer) Receive(ctx context.Context, req *pb.QueueReceiveRequest) (*pb.QueueReceiveResponse, error) {
-	if ok, err := s.checkPluginRegistered(); ok {
-		// Convert gRPC request to plugin params
-		depth := uint32(req.GetDepth())
-		popOptions := sdk.ReceiveOptions{
-			QueueName: req.GetQueue(),
-			Depth:     &depth,
-		}
-
-		// Perform the Queue Receive operation
-		tasks, err := s.plugin.Receive(popOptions)
-		if err != nil {
-			return nil, err
-		}
-
-		// Convert the NitricTasks to the gRPC type
-		grpcTasks := make([]*pb.NitricTask, 0, len(tasks))
-		for _, task := range tasks {
-			st, _ := structpb.NewStruct(task.Payload)
-			grpcTasks = append(grpcTasks, &pb.NitricTask{
-				Id:          task.ID,
-				Payload:     st,
-				LeaseId:     task.LeaseID,
-				PayloadType: task.PayloadType,
-			})
-		}
-
-		// Return the tasks
-		res := pb.QueueReceiveResponse{
-			Tasks: grpcTasks,
-		}
-		return &res, nil
-	} else {
-		return nil, err
+	// Convert gRPC request to plugin params
+	depth := uint32(req.GetDepth())
+	popOptions := sdk.ReceiveOptions{
+		QueueName: req.GetQueue(),
+		Depth:     &depth,
 	}
+
+	// Perform the Queue Receive operation
+	tasks, err := s.plugin.Receive(popOptions)
+	if err != nil {
+		return nil, NewGrpcError("QueueService.Receive", err)
+	}
+
+	// Convert the NitricTasks to the gRPC type
+	grpcTasks := make([]*pb.NitricTask, 0, len(tasks))
+	for _, task := range tasks {
+		st, _ := structpb.NewStruct(task.Payload)
+		grpcTasks = append(grpcTasks, &pb.NitricTask{
+			Id:          task.ID,
+			Payload:     st,
+			LeaseId:     task.LeaseID,
+			PayloadType: task.PayloadType,
+		})
+	}
+
+	// Return the tasks
+	res := pb.QueueReceiveResponse{
+		Tasks: grpcTasks,
+	}
+	return &res, nil
 }
 
 func (s *QueueServiceServer) Complete(ctx context.Context, req *pb.QueueCompleteRequest) (*pb.QueueCompleteResponse, error) {
-	if ok, err := s.checkPluginRegistered(); ok {
-		// Convert gRPC request to plugin params
-		queueName := req.GetQueue()
-		leaseId := req.GetLeaseId()
+	// Convert gRPC request to plugin params
+	queueName := req.GetQueue()
+	leaseId := req.GetLeaseId()
 
-		// Perform the Queue Complete operation
-		err := s.plugin.Complete(queueName, leaseId)
-		if err != nil {
-			return nil, err
-		}
-
-		// Return a successful response
-		return &pb.QueueCompleteResponse{}, nil
-	} else {
-		return nil, err
+	// Perform the Queue Complete operation
+	err := s.plugin.Complete(queueName, leaseId)
+	if err != nil {
+		return nil, NewGrpcError("QueueService.Complete", err)
 	}
+
+	// Return a successful response
+	return &pb.QueueCompleteResponse{}, nil
 }
 
 func NewQueueServiceServer(plugin sdk.QueueService) pb.QueueServiceServer {

--- a/pkg/adapters/grpc/storage_grpc.go
+++ b/pkg/adapters/grpc/storage_grpc.go
@@ -19,8 +19,6 @@ import (
 
 	pb "github.com/nitric-dev/membrane/interfaces/nitric/v1"
 	"github.com/nitric-dev/membrane/pkg/sdk"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // GRPC Interface for registered Nitric Storage Plugins
@@ -29,51 +27,29 @@ type StorageServiceServer struct {
 	storagePlugin sdk.StorageService
 }
 
-// Checks that the storage server is registered and returns gRPC Unimplemented error if not.
-func (s *StorageServiceServer) checkPluginRegistered() (bool, error) {
-	if s.storagePlugin == nil {
-		return false, status.Errorf(codes.Unimplemented, "Storage plugin not registered")
-	}
-
-	return true, nil
-}
-
 func (s *StorageServiceServer) Write(ctx context.Context, req *pb.StorageWriteRequest) (*pb.StorageWriteResponse, error) {
-	if ok, err := s.checkPluginRegistered(); ok {
-		if err := s.storagePlugin.Write(req.GetBucketName(), req.GetKey(), req.GetBody()); err == nil {
-			return &pb.StorageWriteResponse{}, nil
-		} else {
-			return nil, err
-		}
+	if err := s.storagePlugin.Write(req.GetBucketName(), req.GetKey(), req.GetBody()); err == nil {
+		return &pb.StorageWriteResponse{}, nil
 	} else {
-		return nil, err
+		return nil, NewGrpcError("StorageService.Write", err)
 	}
 }
 
 func (s *StorageServiceServer) Read(ctx context.Context, req *pb.StorageReadRequest) (*pb.StorageReadResponse, error) {
-	if ok, err := s.checkPluginRegistered(); ok {
-		if object, err := s.storagePlugin.Read(req.GetBucketName(), req.GetKey()); err == nil {
-			return &pb.StorageReadResponse{
-				Body: object,
-			}, nil
-		} else {
-			return nil, err
-		}
+	if object, err := s.storagePlugin.Read(req.GetBucketName(), req.GetKey()); err == nil {
+		return &pb.StorageReadResponse{
+			Body: object,
+		}, nil
 	} else {
-		return nil, err
+		return nil, NewGrpcError("StorageService.Read", err)
 	}
 }
 
 func (s *StorageServiceServer) Delete(ctx context.Context, req *pb.StorageDeleteRequest) (*pb.StorageDeleteResponse, error) {
-	if ok, err := s.checkPluginRegistered(); ok {
-		if err := s.storagePlugin.Delete(req.GetBucketName(), req.GetKey()); err == nil {
-			return &pb.StorageDeleteResponse{}, nil
-		} else {
-			// TODO: handle specific error codes.
-			return nil, err
-		}
+	if err := s.storagePlugin.Delete(req.GetBucketName(), req.GetKey()); err == nil {
+		return &pb.StorageDeleteResponse{}, nil
 	} else {
-		return nil, err
+		return nil, NewGrpcError("StorageService.Delete", err)
 	}
 }
 

--- a/pkg/adapters/grpc/utils.go
+++ b/pkg/adapters/grpc/utils.go
@@ -1,0 +1,30 @@
+// Copyright 2021 Nitric Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"github.com/nitric-dev/membrane/pkg/plugins"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Provides GRPC error reporting
+func NewGrpcError(operation string, err error) error {
+	if iae, ok := err.(*plugins.InvalidArgumentError); ok {
+		return status.Errorf(codes.InvalidArgument, "%s: %v", operation, iae)
+	} else {
+		return status.Errorf(codes.Internal, "%s: %v", operation, err)
+	}
+}

--- a/pkg/adapters/grpc/utils_test.go
+++ b/pkg/adapters/grpc/utils_test.go
@@ -1,0 +1,43 @@
+// Copyright 2021 Nitric Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc_test
+
+import (
+	"fmt"
+
+	"github.com/nitric-dev/membrane/pkg/adapters/grpc"
+	"github.com/nitric-dev/membrane/pkg/plugins"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GRPC Utils", func() {
+	Context("GrpcError", func() {
+		When("sdk.IllegalArgumentError", func() {
+			It("Should report GRPC IllegalArgument error", func() {
+				err := plugins.NewInvalidArgError("bad param")
+				err = grpc.NewGrpcError("BadServer.BadCall", err)
+				Expect(err.Error()).To(ContainSubstring("rpc error: code = InvalidArgument desc = BadServer.BadCall: bad param"))
+			})
+		})
+		When("Standard Error", func() {
+			It("Should report GRPC Internal error", func() {
+				err := fmt.Errorf("internal error")
+				err = grpc.NewGrpcError("BadServer.BadCall", err)
+				Expect(err.Error()).To(ContainSubstring("rpc error: code = Internal desc = BadServer.BadCall: internal error"))
+			})
+		})
+	})
+})

--- a/pkg/plugins/document/document_test.go
+++ b/pkg/plugins/document/document_test.go
@@ -14,9 +14,9 @@
 package document_test
 
 import (
-	"errors"
-	"github.com/nitric-dev/membrane/pkg/plugins/document"
 	"sort"
+
+	"github.com/nitric-dev/membrane/pkg/plugins/document"
 
 	"github.com/nitric-dev/membrane/pkg/sdk"
 	. "github.com/onsi/ginkgo"
@@ -31,13 +31,13 @@ var _ = Describe("Document Plugin", func() {
 		When("Nil key", func() {
 			It("should return error", func() {
 				err := document.ValidateKey(nil)
-				Expect(err).To(BeEquivalentTo(errors.New("provide non-nil key")))
+				Expect(err.Error()).To(ContainSubstring("provide non-nil key"))
 			})
 		})
 		When("Blank key.Collection", func() {
 			It("should return error", func() {
 				err := document.ValidateKey(&sdk.Key{})
-				Expect(err).To(BeEquivalentTo(errors.New("provide non-blank key.Id")))
+				Expect(err.Error()).To(ContainSubstring("provide non-blank key.Id"))
 			})
 		})
 		When("Blank key.Id", func() {
@@ -46,7 +46,7 @@ var _ = Describe("Document Plugin", func() {
 					Collection: &sdk.Collection{Name: "users"},
 				}
 				err := document.ValidateKey(&key)
-				Expect(err).To(BeEquivalentTo(errors.New("provide non-blank key.Id")))
+				Expect(err.Error()).To(ContainSubstring("provide non-blank key.Id"))
 			})
 		})
 		When("Blank key.Collection.Parent.Collection.Name", func() {
@@ -78,13 +78,13 @@ var _ = Describe("Document Plugin", func() {
 		When("Nil key", func() {
 			It("should return error", func() {
 				err := document.ValidateQueryCollection(nil)
-				Expect(err).To(BeEquivalentTo(errors.New("provide non-nil collection")))
+				Expect(err.Error()).To(ContainSubstring("provide non-nil collection"))
 			})
 		})
 		When("Blank key.Collection", func() {
 			It("should return error", func() {
 				err := document.ValidateQueryCollection(&sdk.Collection{})
-				Expect(err).To(BeEquivalentTo(errors.New("provide non-blank collection.Name")))
+				Expect(err.Error()).To(ContainSubstring("provide non-blank collection.Name"))
 			})
 		})
 		When("Blank key.Id", func() {
@@ -97,9 +97,9 @@ var _ = Describe("Document Plugin", func() {
 		When("Blank key.Collection.Parent.Collection.Name", func() {
 			It("should return error", func() {
 				coll := sdk.Collection{
-					Name:   "users",
+					Name: "users",
 					Parent: &sdk.Key{
-						Id: "test-key",
+						Id:         "test-key",
 						Collection: &sdk.Collection{},
 					},
 				}
@@ -110,9 +110,9 @@ var _ = Describe("Document Plugin", func() {
 		When("Blank collection.Parent.Id", func() {
 			It("should return nil", func() {
 				coll := sdk.Collection{
-					Name:   "orders",
+					Name: "orders",
 					Parent: &sdk.Key{
-						Id: "test-key",
+						Id:         "test-key",
 						Collection: &sdk.Collection{Name: "customers"},
 					},
 				}

--- a/pkg/plugins/document/dynamodb/dynamodb.go
+++ b/pkg/plugins/document/dynamodb/dynamodb.go
@@ -16,9 +16,10 @@ package dynamodb_service
 
 import (
 	"fmt"
+	"sort"
+
 	"github.com/nitric-dev/membrane/pkg/plugins/document"
 	"github.com/nitric-dev/membrane/pkg/utils"
-	"sort"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -27,6 +28,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/nitric-dev/membrane/pkg/sdk"
 )
+
+const ATTRIB_PK = "_pk"
+const ATTRIB_SK = "_sk"
 
 // DynamoDocService - AWS DynamoDB AWS Nitric Document service
 type DynamoDocService struct {
@@ -66,8 +70,8 @@ func (s *DynamoDocService) Get(key *sdk.Key) (*sdk.Document, error) {
 		return nil, fmt.Errorf("error unmarshalling item: %v", err)
 	}
 
-	delete(itemMap, document.ATTRIB_PK)
-	delete(itemMap, document.ATTRIB_SK)
+	delete(itemMap, ATTRIB_PK)
+	delete(itemMap, ATTRIB_SK)
 
 	return &sdk.Document{
 		Content: itemMap,
@@ -227,12 +231,12 @@ func createKeyMap(key *sdk.Key) map[string]string {
 	parentKey := key.Collection.Parent
 
 	if parentKey == nil {
-		keyMap[document.ATTRIB_PK] = key.Id
-		keyMap[document.ATTRIB_SK] = key.Collection.Name + "#"
+		keyMap[ATTRIB_PK] = key.Id
+		keyMap[ATTRIB_SK] = key.Collection.Name + "#"
 
 	} else {
-		keyMap[document.ATTRIB_PK] = parentKey.Id
-		keyMap[document.ATTRIB_SK] = key.Collection.Name + "#" + key.Id
+		keyMap[ATTRIB_PK] = parentKey.Id
+		keyMap[ATTRIB_SK] = key.Collection.Name + "#" + key.Id
 	}
 
 	return keyMap
@@ -248,8 +252,8 @@ func createItemMap(source map[string]interface{}, key *sdk.Key) map[string]inter
 	keyMap := createKeyMap(key)
 
 	// Add key attributes
-	newMap[document.ATTRIB_PK] = keyMap[document.ATTRIB_PK]
-	newMap[document.ATTRIB_SK] = keyMap[document.ATTRIB_SK]
+	newMap[ATTRIB_PK] = keyMap[ATTRIB_PK]
+	newMap[ATTRIB_SK] = keyMap[ATTRIB_SK]
 
 	return newMap
 }
@@ -421,8 +425,8 @@ func marshalQueryResult(
 
 	// Strip keys & append results
 	for _, m := range valueMaps {
-		delete(m, document.ATTRIB_PK)
-		delete(m, document.ATTRIB_SK)
+		delete(m, ATTRIB_PK)
+		delete(m, ATTRIB_SK)
 
 		sdkDoc := sdk.Document{
 			Content: m,

--- a/pkg/plugins/errors.go
+++ b/pkg/plugins/errors.go
@@ -1,0 +1,28 @@
+// Copyright 2021 Nitric Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins
+
+// Provides a illegal argument error for plugin service arguments validation
+type InvalidArgumentError struct {
+	Message string
+}
+
+func (e *InvalidArgumentError) Error() string {
+	return e.Message
+}
+
+func NewInvalidArgError(message string) error {
+	return &InvalidArgumentError{Message: message}
+}

--- a/pluggable_membrane.go
+++ b/pluggable_membrane.go
@@ -22,31 +22,30 @@ import (
 	"strconv"
 	"strings"
 
-	membrane2 "github.com/nitric-dev/membrane/pkg/membrane"
-	utils2 "github.com/nitric-dev/membrane/pkg/utils"
-
+	"github.com/nitric-dev/membrane/pkg/membrane"
 	"github.com/nitric-dev/membrane/pkg/sdk"
+	"github.com/nitric-dev/membrane/pkg/utils"
 )
 
 // Pluggable version of the Nitric membrane
 func main() {
-	serviceAddress := utils2.GetEnv("SERVICE_ADDRESS", "127.0.0.1:50051")
-	childAddress := utils2.GetEnv("CHILD_ADDRESS", "127.0.0.1:8080")
-	pluginDir := utils2.GetEnv("PLUGIN_DIR", "./plugins")
-	serviceFactoryPluginFile := utils2.GetEnv("SERVICE_FACTORY_PLUGIN", "default.so")
+	serviceAddress := utils.GetEnv("SERVICE_ADDRESS", "127.0.0.1:50051")
+	childAddress := utils.GetEnv("CHILD_ADDRESS", "127.0.0.1:8080")
+	pluginDir := utils.GetEnv("PLUGIN_DIR", "./plugins")
+	serviceFactoryPluginFile := utils.GetEnv("SERVICE_FACTORY_PLUGIN", "default.so")
 
 	var childCommand []string
 	// Get the command line arguments, minus the program name in index 0.
 	if len(os.Args) > 1 && len(os.Args[1:]) > 0 {
 		childCommand = os.Args[1:]
 	} else {
-		childCommand = strings.Fields(utils2.GetEnv("INVOKE", ""))
+		childCommand = strings.Fields(utils.GetEnv("INVOKE", ""))
 		if len(childCommand) > 0 {
 			fmt.Println("Warning: use of INVOKE environment variable is deprecated and may be removed in a future version")
 		}
 	}
 
-	tolerateMissingServices := utils2.GetEnv("TOLERATE_MISSING_SERVICES", "false")
+	tolerateMissingServices := utils.GetEnv("TOLERATE_MISSING_SERVICES", "false")
 
 	tolerateMissing, err := strconv.ParseBool(tolerateMissingServices)
 	// Set tolerate missing to false by default so missing plugins will cause a fatal error for safety.
@@ -99,7 +98,7 @@ func main() {
 	}
 
 	// Construct and validate the membrane server
-	membraneServer, err := membrane2.New(&membrane2.MembraneOptions{
+	membraneServer, err := membrane.New(&membrane.MembraneOptions{
 		ServiceAddress:          serviceAddress,
 		ChildAddress:            childAddress,
 		ChildCommand:            childCommand,

--- a/pluggable_membrane.go
+++ b/pluggable_membrane.go
@@ -16,13 +16,14 @@ package main
 
 import (
 	"fmt"
-	membrane2 "github.com/nitric-dev/membrane/pkg/membrane"
-	utils2 "github.com/nitric-dev/membrane/pkg/utils"
 	"log"
 	"os"
 	"plugin"
 	"strconv"
 	"strings"
+
+	membrane2 "github.com/nitric-dev/membrane/pkg/membrane"
+	utils2 "github.com/nitric-dev/membrane/pkg/utils"
 
 	"github.com/nitric-dev/membrane/pkg/sdk"
 )
@@ -73,7 +74,6 @@ func main() {
 	var documentService sdk.DocumentService = nil
 	var eventingService sdk.EventService = nil
 	var gatewayService sdk.GatewayService = nil
-	var keyValueService sdk.KeyValueService = nil
 	var queueService sdk.QueueService = nil
 	var storageService sdk.StorageService = nil
 
@@ -87,10 +87,6 @@ func main() {
 	}
 	// Load the gateway service
 	if gatewayService, err = serviceFactory.NewGatewayService(); err != nil {
-		log.Fatal(err)
-	}
-	// Load the key value service
-	if keyValueService, err = serviceFactory.NewKeyValueService(); err != nil {
 		log.Fatal(err)
 	}
 	// Load the queue service
@@ -109,7 +105,6 @@ func main() {
 		ChildCommand:            childCommand,
 		DocumentPlugin:          documentService,
 		EventingPlugin:          eventingService,
-		KvPlugin:                keyValueService,
 		StoragePlugin:           storageService,
 		GatewayPlugin:           gatewayService,
 		QueuePlugin:             queueService,


### PR DESCRIPTION
This change is to improve client side error reporting from plugin services:

Previously:
```
Error occurred handling request GET / with function: com.example.Handler
io.grpc.StatusRuntimeException: UNKNOWN: provide non-nil key
...
```

PR changes to:
```
Error occurred handling request GET / with function: com.example.Handler
io.grpc.StatusRuntimeException: INVALID_ARGUMENT: DocumentServer.Set: provide non-nil key
...
```