### PR TITLE
feat: support min and max worker config

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ make install-test-tools
 ##### Install Protocol Buffers
 Download the Google Protobuf Compiler (standalone binary called `protoc`) from https://github.com/protocolbuffers/protobuf and add it to your $PATH.
 
-> On Mac OS with Homebrew, you can run `brew install protobuf`
+> On MacOS with Homebrew, you can run `brew install protobuf`
 
 ##### Install Google Cloud SDK
 Install the Google Cloud SDK following in the instructions at: https://cloud.google.com/sdk/docs/install
@@ -214,6 +214,12 @@ make aws-static-xp
 # Set environment variable in subshell, then run the membrane binary
 (export GATEWAY_ENVIRONMENT=http; ./bin/membrane)
 ```
+
+##### Running without a child process
+
+It can be useful to run the Membrane in a 'service only' mode, where the cloud APIs are available but you don't need/want to start a child process to handle incoming request. This can be achieved by setting the MIN_WORKERS variable to `0`:
+
+(export MIN_WORKERS=0; ./bin/membrane)
 
 ## Project Structure
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -11,3 +11,5 @@ In most cases these will already be set as environment variables withing a nitri
 | CHILD_ADDRESS | Sets the address that the child process will be listening on, for requests from the membrane | `127.0.0.1:8080` |
 | INVOKE | Sets the command for the child process that the membrane will execute to begin the child process server | `none` |
 | TOLERATE_MISSING_SERVICES | Enables/Disables the membranes ability to run with an incomplete set of plugins | `false` |
+| MIN_WORKERS | The minimum number of that should be registered before the Membrane will handle triggers or below which the Membrane with shutdown | 1 |
+| MAX_WORKERS | The maximum number of workers that can be registered has trigger handlers with this instance of the Membrane | 1 |

--- a/pkg/sdk/gateway.go
+++ b/pkg/sdk/gateway.go
@@ -43,7 +43,7 @@ type NitricResponse struct {
 type GatewayService interface {
 	// Start the Gateway
 	Start(pool worker.WorkerPool) error
-	// Stops the Gateway
+	// Stop the Gateway
 	Stop() error
 }
 


### PR DESCRIPTION
Setting MIN_WORKERS to 0 enables a 'services only' usage of the Membrane.