### PR TITLE
Fix: Http Gateways not shutting down correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/aws-sdk-go v1.36.12
 	github.com/golang/protobuf v1.5.2
 	github.com/golang/snappy v0.0.3 // indirect
-	github.com/google/addlicense v0.0.0-20210727174409-874627749a46
+	github.com/google/addlicense v0.0.0-20210729153508-ef04bb38a16b
 	github.com/google/uuid v1.1.2
 	github.com/googleapis/gax-go/v2 v2.0.5
 	github.com/jcelliott/lumber v0.0.0-20160324203708-dd349441af25 // indirect

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/google/addlicense v0.0.0-20210428195630-6d92264d7170 h1:jLUa4MO3autxl
 github.com/google/addlicense v0.0.0-20210428195630-6d92264d7170/go.mod h1:EMjYTRimagHs1FwlIqKyX3wAM0u3rA+McvlIIWmSamA=
 github.com/google/addlicense v0.0.0-20210727174409-874627749a46 h1:1locMH9PVZH3LXvogcvdTxf2/9J4YT/9W3BSXrTN4/U=
 github.com/google/addlicense v0.0.0-20210727174409-874627749a46/go.mod h1:EMjYTRimagHs1FwlIqKyX3wAM0u3rA+McvlIIWmSamA=
+github.com/google/addlicense v0.0.0-20210729153508-ef04bb38a16b h1:KwI0NOpYd3rzKojfjeRerF7rzjeTwvJARVsgGf5TWmY=
+github.com/google/addlicense v0.0.0-20210729153508-ef04bb38a16b/go.mod h1:EMjYTRimagHs1FwlIqKyX3wAM0u3rA+McvlIIWmSamA=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/pkg/plugins/gateway/app_platform/http.go
+++ b/pkg/plugins/gateway/app_platform/http.go
@@ -17,6 +17,7 @@ package appplatform_service
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/nitric-dev/membrane/pkg/triggers"
 	"github.com/nitric-dev/membrane/pkg/utils"
@@ -62,7 +63,9 @@ func httpHandler(pool worker.WorkerPool) func(ctx *fasthttp.RequestCtx) {
 
 func (s *HttpGateway) Start(pool worker.WorkerPool) error {
 	s.server = &fasthttp.Server{
-		Handler: httpHandler(pool),
+		IdleTimeout:     time.Second * 1,
+		CloseOnShutdown: true,
+		Handler:         httpHandler(pool),
 	}
 
 	return s.server.ListenAndServe(s.address)

--- a/pkg/plugins/gateway/app_platform/http.go
+++ b/pkg/plugins/gateway/app_platform/http.go
@@ -16,74 +16,12 @@
 package appplatform_service
 
 import (
-	"fmt"
-	"time"
-
-	"github.com/nitric-dev/membrane/pkg/triggers"
-	"github.com/nitric-dev/membrane/pkg/utils"
-	"github.com/nitric-dev/membrane/pkg/worker"
-
 	"github.com/nitric-dev/membrane/pkg/plugins/gateway"
-	"github.com/valyala/fasthttp"
+	"github.com/nitric-dev/membrane/pkg/plugins/gateway/base_http"
 )
-
-type HttpGateway struct {
-	address string
-	server  *fasthttp.Server
-	gateway.UnimplementedGatewayPlugin
-}
-
-func httpHandler(pool worker.WorkerPool) func(ctx *fasthttp.RequestCtx) {
-	return func(ctx *fasthttp.RequestCtx) {
-		wrkr, err := pool.GetWorker()
-
-		if err != nil {
-			ctx.Error("Unable to get worker to handle request", 500)
-			return
-		}
-
-		httpTrigger := triggers.FromHttpRequest(ctx)
-		response, err := wrkr.HandleHttpRequest(httpTrigger)
-
-		if err != nil {
-			ctx.Error(fmt.Sprintf("Error handling HTTP Request: %v", err), 500)
-			return
-		}
-
-		if response.Header != nil {
-			response.Header.CopyTo(&ctx.Response.Header)
-		}
-
-		// Avoid content length header duplication
-		ctx.Response.Header.Del("Content-Length")
-		ctx.Response.SetStatusCode(response.StatusCode)
-		ctx.Response.SetBody(response.Body)
-	}
-}
-
-func (s *HttpGateway) Start(pool worker.WorkerPool) error {
-	s.server = &fasthttp.Server{
-		IdleTimeout:     time.Second * 1,
-		CloseOnShutdown: true,
-		Handler:         httpHandler(pool),
-	}
-
-	return s.server.ListenAndServe(s.address)
-}
-
-func (s *HttpGateway) Stop() error {
-	if s.server != nil {
-		return s.server.Shutdown()
-	}
-	return nil
-}
 
 // Create new HTTP gateway
 // XXX: No External Args for function atm (currently the plugin loader does not pass any argument information)
 func New() (gateway.GatewayService, error) {
-	address := utils.GetEnv("GATEWAY_ADDRESS", ":9001")
-
-	return &HttpGateway{
-		address: address,
-	}, nil
+	return &base_http.New(nil)
 }

--- a/pkg/plugins/gateway/app_platform/http.go
+++ b/pkg/plugins/gateway/app_platform/http.go
@@ -23,5 +23,5 @@ import (
 // Create new HTTP gateway
 // XXX: No External Args for function atm (currently the plugin loader does not pass any argument information)
 func New() (gateway.GatewayService, error) {
-	return &base_http.New(nil)
+	return base_http.New(nil)
 }

--- a/pkg/plugins/gateway/appservice/http.go
+++ b/pkg/plugins/gateway/appservice/http.go
@@ -17,6 +17,7 @@ package http_service
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/nitric-dev/membrane/pkg/triggers"
 	"github.com/nitric-dev/membrane/pkg/utils"
@@ -142,9 +143,10 @@ func httpHandler(pool worker.WorkerPool) func(ctx *fasthttp.RequestCtx) {
 func (s *HttpService) Start(pool worker.WorkerPool) error {
 	// Start the fasthttp server
 	s.server = &fasthttp.Server{
-		Handler: httpHandler(pool),
+		IdleTimeout:     time.Second * 1,
+		CloseOnShutdown: true,
+		Handler:         httpHandler(pool),
 	}
-
 	return s.server.ListenAndServe(s.address)
 }
 

--- a/pkg/plugins/gateway/base_http/http.go
+++ b/pkg/plugins/gateway/base_http/http.go
@@ -1,0 +1,105 @@
+// Copyright 2021 Nitric Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The Digital Ocean App Platform HTTP gateway plugin
+package base_http
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nitric-dev/membrane/pkg/triggers"
+	"github.com/nitric-dev/membrane/pkg/utils"
+	"github.com/nitric-dev/membrane/pkg/worker"
+
+	"github.com/nitric-dev/membrane/pkg/plugins/gateway"
+	"github.com/valyala/fasthttp"
+)
+
+type HttpMiddleware func(*fasthttp.RequestCtx, worker.Worker) bool
+
+type BaseHttpGateway struct {
+	address string
+	server  *fasthttp.Server
+	gateway.UnimplementedGatewayPlugin
+
+	// Middleware for handling events
+	// return bool will indicate whether to continue
+	// to the next (default) behaviour or not...
+	mw HttpMiddleware
+}
+
+func (s *BaseHttpGateway) httpHandler(pool worker.WorkerPool) func(ctx *fasthttp.RequestCtx) {
+	return func(ctx *fasthttp.RequestCtx) {
+		wrkr, err := pool.GetWorker()
+
+		if err != nil {
+			ctx.Error("Unable to get worker to handle request", 500)
+			return
+		}
+
+		if s.mw != nil {
+			if !s.mw(ctx, wrkr) {
+				// middleware has indicated that is has processed the request
+				// so we can exit here
+				return
+			}
+		}
+
+		httpTrigger := triggers.FromHttpRequest(ctx)
+		response, err := wrkr.HandleHttpRequest(httpTrigger)
+
+		if err != nil {
+			ctx.Error(fmt.Sprintf("Error handling HTTP Request: %v", err), 500)
+			return
+		}
+
+		if response.Header != nil {
+			response.Header.CopyTo(&ctx.Response.Header)
+		}
+
+		// Avoid content length header duplication
+		ctx.Response.Header.Del("Content-Length")
+		ctx.Response.SetStatusCode(response.StatusCode)
+		ctx.Response.SetBody(response.Body)
+	}
+}
+
+func (s *BaseHttpGateway) Start(pool worker.WorkerPool) error {
+	s.server = &fasthttp.Server{
+		IdleTimeout:     time.Second * 1,
+		CloseOnShutdown: true,
+		Handler:         s.httpHandler(pool),
+	}
+
+	return s.server.ListenAndServe(s.address)
+}
+
+func (s *BaseHttpGateway) Stop() error {
+	if s.server != nil {
+		return s.server.Shutdown()
+	}
+	return nil
+}
+
+// Create new HTTP gateway
+// XXX: No External Args for function atm (currently the plugin loader does not pass any argument information)
+func New(mw HttpMiddleware) (gateway.GatewayService, error) {
+	address := utils.GetEnv("GATEWAY_ADDRESS", ":9001")
+
+	return &BaseHttpGateway{
+		address: address,
+		mw:      mw,
+	}, nil
+}

--- a/pkg/plugins/gateway/cloudrun/http.go
+++ b/pkg/plugins/gateway/cloudrun/http.go
@@ -18,6 +18,7 @@ package cloudrun_plugin
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/nitric-dev/membrane/pkg/triggers"
 	"github.com/nitric-dev/membrane/pkg/utils"
@@ -100,7 +101,9 @@ func httpHandler(pool worker.WorkerPool) func(ctx *fasthttp.RequestCtx) {
 func (s *HttpProxyGateway) Start(pool worker.WorkerPool) error {
 	// Start the fasthttp server
 	s.server = &fasthttp.Server{
-		Handler: httpHandler(pool),
+		IdleTimeout:     time.Second * 1,
+		CloseOnShutdown: true,
+		Handler:         httpHandler(pool),
 	}
 
 	return s.server.ListenAndServe(s.address)

--- a/pkg/plugins/gateway/cloudrun/http.go
+++ b/pkg/plugins/gateway/cloudrun/http.go
@@ -18,20 +18,14 @@ package cloudrun_plugin
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/nitric-dev/membrane/pkg/triggers"
-	"github.com/nitric-dev/membrane/pkg/utils"
 	"github.com/nitric-dev/membrane/pkg/worker"
 
 	"github.com/nitric-dev/membrane/pkg/plugins/gateway"
+	"github.com/nitric-dev/membrane/pkg/plugins/gateway/base_http"
 	"github.com/valyala/fasthttp"
 )
-
-type HttpProxyGateway struct {
-	address string
-	server  *fasthttp.Server
-}
 
 type PubSubMessage struct {
 	Message struct {
@@ -42,86 +36,41 @@ type PubSubMessage struct {
 	Subscription string `json:"subscription"`
 }
 
-func httpHandler(pool worker.WorkerPool) func(ctx *fasthttp.RequestCtx) {
-	return func(ctx *fasthttp.RequestCtx) {
-		wrkr, err := pool.GetWorker()
-		if err != nil {
-			ctx.Error("Unable to get worker to handle request", 500)
-			return
+func middleware(ctx *fasthttp.RequestCtx, wrkr worker.Worker) bool {
+	bodyBytes := ctx.Request.Body()
+
+	// Check if the payload contains a pubsub event
+	// TODO: We probably want to use a simpler method than this
+	// like reading off the request origin to ensure it is from pubsub
+	var pubsubEvent PubSubMessage
+	if err := json.Unmarshal(bodyBytes, &pubsubEvent); err == nil && pubsubEvent.Subscription != "" {
+		// We have an event from pubsub here...
+		event := &triggers.Event{
+			ID: pubsubEvent.Message.ID,
+			// Set the topic
+			Topic: pubsubEvent.Message.Attributes["x-nitric-topic"],
+			// Set the payload
+			Payload: pubsubEvent.Message.Data,
 		}
 
-		bodyBytes := ctx.Request.Body()
-
-		// Check if the payload contains a pubsub event
-		// TODO: We probably want to use a simpler method than this
-		// like reading off the request origin to ensure it is from pubsub
-		var pubsubEvent PubSubMessage
-		if err := json.Unmarshal(bodyBytes, &pubsubEvent); err == nil && pubsubEvent.Subscription != "" {
-			// We have an event from pubsub here...
-			event := &triggers.Event{
-				ID: pubsubEvent.Message.ID,
-				// Set the topic
-				Topic: pubsubEvent.Message.Attributes["x-nitric-topic"],
-				// Set the payload
-				Payload: pubsubEvent.Message.Data,
-			}
-
-			if err := wrkr.HandleEvent(event); err == nil {
-				// return a successful response
-				ctx.SuccessString("text/plain", "success")
-			} else {
-				ctx.Error(fmt.Sprintf("Error handling event %v", err), 500)
-			}
-
-			return
+		if err := wrkr.HandleEvent(event); err == nil {
+			// return a successful response
+			ctx.SuccessString("text/plain", "success")
+		} else {
+			ctx.Error(fmt.Sprintf("Error handling event %v", err), 500)
 		}
 
-		httpTrigger := triggers.FromHttpRequest(ctx)
-		response, err := wrkr.HandleHttpRequest(httpTrigger)
-
-		if err != nil {
-			ctx.Error(fmt.Sprintf("Error handling HTTP Request: %v", err), 500)
-			return
-		}
-		// responseBody, _ := ioutil.ReadAll(response.Body)
-		if response.Header != nil {
-			// Set headers...
-			response.Header.VisitAll(func(key []byte, val []byte) {
-				ctx.Response.Header.AddBytesKV(key, val)
-			})
-		}
-
-		// Avoid content length header duplication
-		ctx.Response.Header.Del("Content-Length")
-		ctx.Response.SetStatusCode(response.StatusCode)
-		ctx.Response.SetBody(response.Body)
-	}
-}
-
-func (s *HttpProxyGateway) Start(pool worker.WorkerPool) error {
-	// Start the fasthttp server
-	s.server = &fasthttp.Server{
-		IdleTimeout:     time.Second * 1,
-		CloseOnShutdown: true,
-		Handler:         httpHandler(pool),
+		// We've already handled the request
+		// do not continue processing
+		return false
 	}
 
-	return s.server.ListenAndServe(s.address)
+	// Let the base plugin handle the request
+	return true
 }
 
-func (s *HttpProxyGateway) Stop() error {
-	if s.server != nil {
-		return s.server.Shutdown()
-	}
-	return nil
-}
-
-// Create new DynamoDB documents server
-// XXX: No External Args for function atm (currently the plugin loader does not pass any argument information)
+// New - Create a New cloudrun gateway plugin
 func New() (gateway.GatewayService, error) {
-	address := utils.GetEnv("GATEWAY_ADDRESS", "0.0.0.0:9001")
-
-	return &HttpProxyGateway{
-		address: address,
-	}, nil
+	// plugin is derived from base http plugin
+	return base_http.New(middleware)
 }

--- a/pkg/plugins/gateway/dev/gateway.go
+++ b/pkg/plugins/gateway/dev/gateway.go
@@ -18,105 +18,46 @@ package gateway_plugin
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/nitric-dev/membrane/pkg/triggers"
-	"github.com/nitric-dev/membrane/pkg/utils"
 	"github.com/nitric-dev/membrane/pkg/worker"
 
 	"github.com/nitric-dev/membrane/pkg/plugins/gateway"
+	"github.com/nitric-dev/membrane/pkg/plugins/gateway/base_http"
 	"github.com/valyala/fasthttp"
 )
 
-type HttpGateway struct {
-	address string
-	server  *fasthttp.Server
-	gateway.UnimplementedGatewayPlugin
-}
+func middleware(ctx *fasthttp.RequestCtx, wrkr worker.Worker) bool {
+	var triggerTypeString = string(ctx.Request.Header.Peek("x-nitric-source-type"))
 
-// TODO: Lets bind this to a struct...
-func httpHandler(pool worker.WorkerPool) func(ctx *fasthttp.RequestCtx) {
-	return func(ctx *fasthttp.RequestCtx) {
-		// Get a worker for this request
-		wrkr, err := pool.GetWorker()
+	// Handle Event/Subscription Request Types
+	if strings.ToUpper(triggerTypeString) == triggers.TriggerType_Subscription.String() {
+		trigger := string(ctx.Request.Header.Peek("x-nitric-source"))
+		requestId := string(ctx.Request.Header.Peek("x-nitric-request-id"))
+		payload := ctx.Request.Body()
 
-		if err != nil {
-			ctx.Error("Unable to get worker for this event", 500)
-			return
-		}
-
-		var triggerTypeString = string(ctx.Request.Header.Peek("x-nitric-source-type"))
-
-		// Handle Event/Subscription Request Types
-		if strings.ToUpper(triggerTypeString) == triggers.TriggerType_Subscription.String() {
-			trigger := string(ctx.Request.Header.Peek("x-nitric-source"))
-			requestId := string(ctx.Request.Header.Peek("x-nitric-request-id"))
-			payload := ctx.Request.Body()
-
-			err := wrkr.HandleEvent(&triggers.Event{
-				ID:      requestId,
-				Topic:   trigger,
-				Payload: payload,
-			})
-
-			if err != nil {
-				fmt.Println(err)
-				ctx.Error(fmt.Sprintf("Error processing event. Details: %s", err), 500)
-			} else {
-				ctx.SuccessString("text/plain", "Successfully Handled the Event")
-			}
-
-			// return here...
-			return
-		}
-
-		httpReq := triggers.FromHttpRequest(ctx)
-		// Handle HTTP Request Types
-		response, err := wrkr.HandleHttpRequest(httpReq)
+		err := wrkr.HandleEvent(&triggers.Event{
+			ID:      requestId,
+			Topic:   trigger,
+			Payload: payload,
+		})
 
 		if err != nil {
-			// TODO: Redact message in production
-			ctx.Error(err.Error(), 500)
-			return
+			fmt.Println(err)
+			ctx.Error(fmt.Sprintf("Error processing event. Details: %s", err), 500)
+		} else {
+			ctx.SuccessString("text/plain", "Successfully Handled the Event")
 		}
 
-		if response.Header != nil {
-			response.Header.CopyTo(&ctx.Response.Header)
-		}
-
-		ctx.Response.Header.Del("Content-Length")
-		ctx.Response.Header.Del("Connection")
-
-		ctx.Response.SetBody(response.Body)
-		ctx.Response.SetStatusCode(response.StatusCode)
-	}
-}
-
-func (s *HttpGateway) Start(pool worker.WorkerPool) error {
-	// Start the fasthttp server
-	s.server = &fasthttp.Server{
-		IdleTimeout:     time.Second * 1,
-		CloseOnShutdown: true,
-		Handler:         httpHandler(pool),
+		// return here...
+		return false
 	}
 
-	return s.server.ListenAndServe(s.address)
-}
-
-func (s *HttpGateway) Stop() error {
-	if s.server != nil {
-		fmt.Println("Shutting down, waiting for open connections: ", s.server.GetOpenConnectionsCount())
-		return s.server.Shutdown()
-	}
-	return nil
+	return true
 }
 
 // Create new HTTP gateway
 // XXX: No External Args for function atm (currently the plugin loader does not pass any argument information)
 func New() (gateway.GatewayService, error) {
-	address := utils.GetEnv("GATEWAY_ADDRESS", ":9001")
-
-	return &HttpGateway{
-		address: address,
-	}, nil
+	return base_http.New(middleware)
 }

--- a/pkg/plugins/gateway/dev/gateway.go
+++ b/pkg/plugins/gateway/dev/gateway.go
@@ -18,6 +18,7 @@ package gateway_plugin
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/nitric-dev/membrane/pkg/triggers"
 	"github.com/nitric-dev/membrane/pkg/utils"
@@ -94,7 +95,9 @@ func httpHandler(pool worker.WorkerPool) func(ctx *fasthttp.RequestCtx) {
 func (s *HttpGateway) Start(pool worker.WorkerPool) error {
 	// Start the fasthttp server
 	s.server = &fasthttp.Server{
-		Handler: httpHandler(pool),
+		IdleTimeout:     time.Second * 1,
+		CloseOnShutdown: true,
+		Handler:         httpHandler(pool),
 	}
 
 	return s.server.ListenAndServe(s.address)
@@ -102,6 +105,7 @@ func (s *HttpGateway) Start(pool worker.WorkerPool) error {
 
 func (s *HttpGateway) Stop() error {
 	if s.server != nil {
+		fmt.Println("Shutting down, waiting for open connections: ", s.server.GetOpenConnectionsCount())
 		return s.server.Shutdown()
 	}
 	return nil

--- a/pkg/plugins/gateway/ecs/ecs.go
+++ b/pkg/plugins/gateway/ecs/ecs.go
@@ -18,6 +18,7 @@ package ecs_service
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/nitric-dev/membrane/pkg/triggers"
 	"github.com/nitric-dev/membrane/pkg/utils"
@@ -115,7 +116,9 @@ func (s *HttpProxyGateway) httpHandler(pool worker.WorkerPool) func(*fasthttp.Re
 func (s *HttpProxyGateway) Start(pool worker.WorkerPool) error {
 	// Start the fasthttp server
 	s.server = &fasthttp.Server{
-		Handler: s.httpHandler(pool),
+		IdleTimeout:     time.Second * 1,
+		CloseOnShutdown: true,
+		Handler:         s.httpHandler(pool),
 	}
 
 	return s.server.ListenAndServe(s.address)


### PR DESCRIPTION
Have also included refactoring increase maintainability of http base gateway plugins by allowing them to share a common base plugin, with intercepting middleware.

Middleware is very bare bones at the moment, but we can add additional functionality and richness later.